### PR TITLE
Handle pg syntax error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ app/styles/
 dist/
 node_modules/
 server/.env
+.idea/
 .env
 npm-debug.log
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "migrate-up": "db-migrate -m ./server/migrations up",
     "pack": "yarn run clean && yarn run build-app-client && yarn run build-game && electron-builder build --dir --win --x64 -c prod.yml",
     "packstaging": "yarn run clean && cross-env SB_SERVER=https://staging.shieldbattery.net yarn run build-app-client && yarn run build-game && electron-builder build --dir --win --x64 -c staging.yml",
-    "start-server": "node ./server/index.js | node ./server/utils/pino-pg | pino-pretty -c -t",
+    "start-server": "node ./server/index.js | node ./server/utils/pino-pg",
     "test": "jest",
     "testonly": "jest",
     "typecheck": "tsc --skipLibCheck false",

--- a/server/lib/db/index.ts
+++ b/server/lib/db/index.ts
@@ -1,6 +1,7 @@
 import pg from 'pg'
 import { isTestRun } from '../../../common/is-test-run'
 import log from '../logging/logger'
+import parseError from './pg-error-parser'
 
 /**
  * The amount of time queries are allowed to run for before they are considered "slow" and logged
@@ -63,7 +64,9 @@ export class DbClient {
     const queryText = isQueryConfig(queryTextOrConfig) ? queryTextOrConfig.text : queryTextOrConfig
     const startTime = Date.now()
     try {
-      return this.wrappedClient.query(queryTextOrConfig, values)
+      return this.wrappedClient.query(queryTextOrConfig, values).catch(error => {
+        throw parseError(queryText, error)
+      })
     } finally {
       const totalTime = Date.now() - startTime
       if (totalTime > SLOW_QUERY_TIME_MS) {

--- a/server/lib/db/pg-error-parser.ts
+++ b/server/lib/db/pg-error-parser.ts
@@ -1,0 +1,42 @@
+import { SYNTAX_ERROR_OR_ACCESS_RULE_VIOLATION } from './pg-error-codes'
+
+export default function parseError(query: string, error: any): Error {
+  if (
+    error.code &&
+    error.code.substring(0, 2) === SYNTAX_ERROR_OR_ACCESS_RULE_VIOLATION.substring(0, 2) &&
+    error.position
+  ) {
+    return parseSyntaxError(query, error)
+  }
+  return new Error(`${error.message} in query ${query}`)
+}
+
+function parseSyntaxError(queryText: string, error: any): Error {
+  let queryLines = queryText.split('\n')
+
+  let cursor = 0
+  let lineNumber = 0
+  let relativePosition = 0
+  let foundPosition = false
+  for (let i = 0; i < queryLines.length && !foundPosition; i++) {
+    lineNumber += 1
+    // We need to count the new line character
+    cursor += 1
+    const line = queryLines[i]
+    for (let j = 0; j < line.length; j++) {
+      if (cursor === parseInt(error.position)) {
+        foundPosition = true
+        relativePosition = j
+        break
+      }
+      cursor += 1
+    }
+  }
+
+  const caretLine = '^'.padStart(relativePosition + 1)
+  queryLines.splice(lineNumber, 0, caretLine)
+
+  return new Error(
+    `${error.message} at position ${error.position} in query ${queryLines.join('\n')}`,
+  )
+}

--- a/server/lib/logging/logger.ts
+++ b/server/lib/logging/logger.ts
@@ -8,5 +8,7 @@ export function getLoggerOptions() {
     level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
     genReqId: cuid,
     serializers: stdSerializers,
+    prettyPrint: { colorize: true },
+    translateTime: true,
   }
 }


### PR DESCRIPTION
Example log
```
    err: {
      "type": "Error",
      "message": "column \"asdfchannel_name\" does not exist at position 15 in query \n      SELECT asdfchannel_name, join_date\n             ^\n      FROM joined_channels\n      WHERE user_id = $1\n      ORDER BY join_date",
      "stack":
          Error: column "asdfchannel_name" does not exist at position 15 in query
                SELECT asdfchannel_name, join_date
                       ^
                FROM joined_channels
                WHERE user_id = $1
                ORDER BY join_date
              at getChannelsForUser (C:\Users\willi\Code\ShieldBattery\server\lib\chat\/chat-models.ts:70:11)
              at processTicksAndRejections (internal/process/task_queues.js:95:5)
              at ChatService.handleNewUser (C:\Users\willi\Code\ShieldBattery\server\lib\chat\/chat-service.ts:226:29)
    }
```
    
Just putting this up as an example before building out support of more error types